### PR TITLE
Update URL to Libcal's API 

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,6 +10,10 @@
       "description": "Likely a 3 digit number. Can be found in the LibCal API interface under the Authentication tab.",
       "required": true
     },
+    "LIBCAL_ORGANIZATION_URL": {
+      "description": "The URL for your libcal instance; likely will end in .libcal.com ; Can be found in the LibCal API interface under the Authentication tab.",
+      "required": true
+    },
     "LIBCAL_CLIENT_SECRET": {
       "description": "A big long bit of gibberish. Can be found in the LibCal API interface under the Authentication tab.",
       "required": true

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "auth-server-for-springshare",
-  "version": "1.0.0",
-  "description":
-    "A Node server that works with the LibCal and LibGuides API v1.2 endpoints and returns your requested data.",
+  "version": "1.0.3",
+  "description": "A Node server that works with the LibCal and LibGuides API v1.2 endpoints and returns your requested data.",
   "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -12,7 +11,14 @@
     "type": "git",
     "url": "git+https://github.com/BradCoffield/auth-server-for-springshare.git"
   },
-  "keywords": ["node", "express", "springshare", "libguides", "libcal", "API"],
+  "keywords": [
+    "node",
+    "express",
+    "springshare",
+    "libguides",
+    "libcal",
+    "API"
+  ],
   "author": "Brad Coffield",
   "license": "ISC",
   "bugs": {
@@ -22,6 +28,7 @@
   "dependencies": {
     "axios": "^0.17.1",
     "cors": "^2.8.4",
+    "dotenv": "^16.0.3",
     "express": "^4.16.2",
     "node-cache": "^4.1.1"
   }

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const express = require("express");
 const cors = require("cors");
 const fs = require("fs");
 const _ = require("lodash");
+require("dotenv").config();
 
 const myCache = new NodeCache();
 const port = process.env.PORT || 3000;
@@ -12,7 +13,7 @@ const app = express();
 app.use(
   cors({
     credentials: true,
-    origin: true
+    origin: true,
   })
 );
 
@@ -21,7 +22,7 @@ app.use((req, res, next) => {
   var now = new Date().toString();
   var log = `${now}: ${req.method} ${req.url}`;
   console.log(log);
-  fs.appendFile(`server.log`, log + "\n", err => {
+  fs.appendFile(`server.log`, log + "\n", (err) => {
     if (err) {
       console.log(`Unable to append to server.log`);
     }
@@ -43,14 +44,14 @@ app.get("/springshare/libcal/:passthrough", (req, res, next) => {
   let dealingWithInput = _.keys(req.query);
 
   if (dealingWithInput.length > 1) {
-    let cleanedNoWhatInput = dealingWithInput.filter(word => word != "what");
+    let cleanedNoWhatInput = dealingWithInput.filter((word) => word != "what");
 
-    cleanedNoWhatInput.map(parram => {
+    cleanedNoWhatInput.map((parram) => {
       cleanParams += `&${parram}=${req.query[parram]}`;
     });
   }
 
-  const urlFront = "https://api2.libcal.com/1.1";
+  const urlFront = "https://" + process.env.LIBCAL_ORGANIZATION_URL + "/1.1";
 
   const springshareAuth = require("./springshare/springshareAuth");
   const fetchSpringshare = require("./springshare/fetch-springshare");
@@ -58,7 +59,7 @@ app.get("/springshare/libcal/:passthrough", (req, res, next) => {
   const springshareAuthObj = {
     client_id: process.env.LIBCAL_CLIENT_ID,
     client_secret: process.env.LIBCAL_CLIENT_SECRET,
-    grant_type: "client_credentials"
+    grant_type: "client_credentials",
   };
   let sendSpringshareResults = (err, content) => {
     if (err) {
@@ -70,7 +71,12 @@ app.get("/springshare/libcal/:passthrough", (req, res, next) => {
     if (err) {
       return res.send("ahhhhh!,", err);
     }
-    fetchSpringshare.fetchSpringshare(token, cleanParams, urlFront, sendSpringshareResults);
+    fetchSpringshare.fetchSpringshare(
+      token,
+      cleanParams,
+      urlFront,
+      sendSpringshareResults
+    );
   };
 
   springshareAuth.springshareAuth(springshareAuthObj, service, gSpSt);
@@ -83,14 +89,14 @@ app.get("/springshare/libguides/:passthrough", (req, res, next) => {
   const lgAuthObj = {
     client_id: process.env.LIBGUIDES_CLIENT_ID,
     client_secret: process.env.LIBGUIDES_CLIENT_SECRET,
-    grant_type: "client_credentials"
+    grant_type: "client_credentials",
   };
   const service = "libguides";
   let cleanParams = req.query.what;
   let dealingWithInput = _.keys(req.query);
   if (dealingWithInput.length > 1) {
-    let cleanedNoWhatInput = dealingWithInput.filter(word => word != "what");
-    cleanedNoWhatInput.map(parram => {
+    let cleanedNoWhatInput = dealingWithInput.filter((word) => word != "what");
+    cleanedNoWhatInput.map((parram) => {
       cleanParams += `&${parram}=${req.query[parram]}`;
     });
   }
@@ -108,7 +114,12 @@ app.get("/springshare/libguides/:passthrough", (req, res, next) => {
     if (err) {
       return res.send("ahhhhh!,", err);
     }
-    fetchSpringshare.fetchSpringshare(token, cleanParams, urlFront, sendSpringshareResults);
+    fetchSpringshare.fetchSpringshare(
+      token,
+      cleanParams,
+      urlFront,
+      sendSpringshareResults
+    );
   };
 
   springshareAuth.springshareAuth(lgAuthObj, service, gSpSt);

--- a/springshare/springshareAuth.js
+++ b/springshare/springshareAuth.js
@@ -1,34 +1,41 @@
 const axios = require("axios");
 const NodeCache = require("node-cache");
+require("dotenv").config();
 
 const myCache = new NodeCache();
 
-let springshareAuth = function(key, service, callback) {
+let springshareAuth = function (key, service, callback) {
   if (myCache.get(`${service}_token_key`) == undefined) {
     if (service == "libcal") {
-      var authServer = "https://api2.libcal.com/1.1/oauth/token";
+      var authServer =
+        "https://" + process.env.LIBCAL_ORGANIZATION_URL + "/1.1/oauth/token";
     } else {
       var authServer = "https://lgapi-us.libapps.com/1.2/oauth/token";
     }
     axios
       .post(authServer, key)
-      .then(function(response) {
+      .then(function (response) {
         access_token_4u = response.data.access_token;
       })
-      .then(function(response) {
-        myCache.set(`${service}_token_key`, access_token_4u, 3500, function(err, success) {
-          if (!err && success) {
-            console.log("setting auth cache", success);
-            return callback(null, access_token_4u);
+      .then(function (response) {
+        myCache.set(
+          `${service}_token_key`,
+          access_token_4u,
+          3500,
+          function (err, success) {
+            if (!err && success) {
+              console.log("setting auth cache", success);
+              return callback(null, access_token_4u);
+            }
           }
-        });
+        );
       })
-      .catch(function(error) {
+      .catch(function (error) {
         console.log("garh", error);
       });
   } else {
     console.log("sup");
-    myCache.get(`${service}_token_key`, function(err, value) {
+    myCache.get(`${service}_token_key`, function (err, value) {
       if (!err) {
         if (value == undefined) {
           console.log("key not found");


### PR DESCRIPTION
Hi,
 
The URL used to contact the Libcal API has changed; the previous URL - https://api2.libcal.com/ - is no longer used. Unfortunately, I cannot find a public changelog of this; the API change is mentioned at https://lounge.springshare.com/discussion/1258/libcal-december-2022-release#latest as well as in an email that was sent out to libcal administrators from springshare. 

Instead, each organization has a custom URL that I believes matches the root of the organizations (in my organization's case, `cpl.libcal.com`). 

I've changed it so that the URL is now set to the LIBCAL_ORGANIZATION_URL environment variable. 

I did also have to add the dotenv package in order to read the environmental (.env) variables locally. 

We're using these changes now in production on our heroku instance that feeds into cpl.org 

There are likely changes to Libguides but I did not make them; we do not use libguides. 

Lastly, I did notice that some linting changes were unintentionally introduced; I'll revert that if yo uwish. 